### PR TITLE
Take into account `repeated` flag for types

### DIFF
--- a/src/google-api-typings-generator.ts
+++ b/src/google-api-typings-generator.ts
@@ -376,7 +376,8 @@ function getType(type: gapi.client.discovery.JsonSchema, schemas: Record<string,
         }
     }
     else if (type.type) {
-        return typesMap[type.type] || type.type;
+        const tsType = typesMap[type.type] || type.type;
+        return type.repeated ? `tsType | Array<${tsType}>` : tsType;
     }
     else if (type.$ref) {
         const referencedType = schemas[type.$ref];


### PR DESCRIPTION
For example, `gapi.client.sheets.spreadsheets.values.batchGet` accepts either string or array of strings. This patch takes that into account.
````JSON
"ranges": {
  "location": "query",
  "description": "The ranges to retrieve from the spreadsheet.",
  "type": "string",
  "repeated": true
}
````