### PR TITLE
Fix compiler errors and allow user to specify output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,7 @@ This project using [Google API discovery](https://developers.google.com/discover
 ## Usage
 Run program:
 ```
-npm start
+npm start --out /path/to/DefinitelyTyped/types/
 ```
+
+If you don't provide a value for `--out`, the default is a directory named `out` in the working directory.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Google API Typescript typings definitions generator",
   "main": "generator.ts",
   "scripts": {
-    "start": "ts-node src/google-api-typings-generator.ts --out D:\\Projects\\GitHub\\DefinitelyTyped\\types",
+    "start": "ts-node src/google-api-typings-generator.ts",
     "tsc": "tsc -p .",
     "test": "mocha tests/tests.ts --require ts-node/register"
   },

--- a/src/google-api-typings-generator.ts
+++ b/src/google-api-typings-generator.ts
@@ -107,6 +107,7 @@ interface ITypescriptTextWriter {
 }
 
 type TypescriptWriterCallback = (writer: TypescriptTextWriter) => void;
+type methodParam = { parameter: string, type: string | TypescriptWriterCallback };
 
 function formatPropertyName(name: string) {
     if (name.indexOf(".") >= 0 || name.indexOf("-") >= 0 || name.indexOf("@") >= 0) {
@@ -256,7 +257,8 @@ class TypescriptTextWriter implements ITypescriptTextWriter {
         }
     }
 
-    public method(name: string, parameters: [{ parameter: string, type: string | TypescriptWriterCallback }], returnType: string, singleLine = false) {
+
+    public method(name: string, parameters: methodParam[], returnType: string, singleLine = false) {
         this.writer.startIndentedLine(`${name}(`);
 
         _.forEach(parameters, (parameter, index) => {


### PR DESCRIPTION
Came across some issues with an out-of-date type definition for one of the Google APIs. That led me back to your tool, and in order to regenerate the definition I was working on, I needed to make these changes. Hope they're helpful, and thanks for writing this!